### PR TITLE
(hotfix) bump actions/setup-java version to fix cache error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: 8
           distribution: 'temurin'


### PR DESCRIPTION
Fix CI by bumping actions/setup-java version