### PR TITLE
(hofix) Upgrade the maven-shade-plugin version from 3.1.1 to 3.4.0 to resolve Maven compilation exceptions.

### DIFF
--- a/amoro-shade-jackson-parent/amoro-shade-jackson-2/pom.xml
+++ b/amoro-shade-jackson-parent/amoro-shade-jackson-2/pom.xml
@@ -24,7 +24,7 @@ under the License.
     <parent>
         <groupId>org.apache.amoro</groupId>
         <artifactId>amoro-shade-jackson-parent</artifactId>
-        <version>2.14.2-0.9-SNAPSHOT</version>
+        <version>2.15.0-0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>amoro-shade-jackson-2</artifactId>

--- a/amoro-shade-jackson-parent/amoro-shade-jackson-module-jsonSchema-2/pom.xml
+++ b/amoro-shade-jackson-parent/amoro-shade-jackson-module-jsonSchema-2/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.amoro</groupId>
         <artifactId>amoro-shade-jackson-parent</artifactId>
-        <version>2.14.2-0.9-SNAPSHOT</version>
+        <version>2.15.0-0.9-SNAPSHOT</version>
     </parent>
 
     <artifactId>amoro-shade-jackson-module-jsonSchema-2</artifactId>

--- a/amoro-shade-jackson-parent/pom.xml
+++ b/amoro-shade-jackson-parent/pom.xml
@@ -29,12 +29,12 @@ under the License.
 
     <artifactId>amoro-shade-jackson-parent</artifactId>
     <name>amoro-shade-jackson-parent</name>
-    <version>2.14.2-0.9-SNAPSHOT</version>
+    <version>2.15.0-0.9-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
     <properties>
-        <jackson.version>2.14.2</jackson.version>
+        <jackson.version>2.15.0</jackson.version>
     </properties>
     <modules>
         <module>amoro-shade-jackson-2</module>

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.4.0</version>
                     <configuration>
                         <filters combine.children="append">
                             <filter>


### PR DESCRIPTION
Fix the compile error by upgrading Jackson version to 2.15.0 as follow:
 when maven-shade-plugin version is 3.1.1:
<img width="979" height="145" alt="image" src="https://github.com/user-attachments/assets/f2fc3844-954a-4944-88f1-12587f2c994c" />

 when maven-shade-plugin version is 3.2.4:
<img width="1598" height="115" alt="image" src="https://github.com/user-attachments/assets/2a8106a8-125a-4d4a-a34f-b8f3331d8900" />

 when maven-shade-plugin version is 3.3.0:
<img width="1632" height="156" alt="image" src="https://github.com/user-attachments/assets/094b7439-efbb-4ff9-90ba-b4880d32469d" />

the maven-shade-plugin version is 3.2.4 in https://github.com/apache/amoro/blob/master/pom.xml